### PR TITLE
Use PlayerInteractEvent instead of PlayerMoveEvent in launchpads

### DIFF
--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/world/Launchpad.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/world/Launchpad.java
@@ -9,7 +9,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerMoveEvent;
 
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.config.ConfigType;
@@ -52,7 +51,7 @@ public class Launchpad extends Module {
     }
 
     @EventHandler
-    public void onPlayerMove(PlayerInteractEvent event) {
+    public void onLaunchPadInteract(PlayerInteractEvent event) {
         if(event.getAction() != Action.PHYSICAL) return;
         Player player = event.getPlayer();
         Location location = player.getLocation();

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/world/Launchpad.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/world/Launchpad.java
@@ -7,6 +7,8 @@ import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
@@ -50,14 +52,15 @@ public class Launchpad extends Module {
     }
 
     @EventHandler
-    public void onPlayerMove(PlayerMoveEvent event) {
+    public void onPlayerMove(PlayerInteractEvent event) {
+        if(event.getAction() != Action.PHYSICAL) return;
         Player player = event.getPlayer();
         Location location = player.getLocation();
         if (inDisabledWorld(location))
             return;
 
         // Check for launchpad block and cooldown
-        if (location.getBlock().getType() == topBlock && location.subtract(0, 1, 0).getBlock().getType() == bottomBlock
+        if (event.getMaterial() == topBlock && location.subtract(0, 1, 0).getBlock().getType() == bottomBlock
                 && tryCooldown(player.getUniqueId(), CooldownType.LAUNCHPAD, 1)) {
             player.setVelocity(location.getDirection().multiply(launch).setY(launchY));
             executeActions(player, actions);


### PR DESCRIPTION
- The PlayerMoveEvent is a very heavy event that is executed at every slightest movement of every player on the server.
Therefore, change the event with which the launchpad works to PlayerInteractEvent with a fastreturn at the beginning of the event for the best performance.